### PR TITLE
fix(Units): Change $units to default to 'metric' (ie. Celsius). 

### DIFF
--- a/code/services/OpenWeatherService.php
+++ b/code/services/OpenWeatherService.php
@@ -4,9 +4,22 @@
  * @author marcus
  */
 class OpenWeatherService {
+    /** 
+     * @var string
+     */
     public $endpoint = 'http://api.openweathermap.org';
+
+    /** 
+     * @var string
+     */
     public $key = '';
-    public $units;
+
+    /** 
+     * Default to Celsius.
+     *
+     * @var string
+     */
+    public $units = 'metric';
 
     public function forecastFor($location) {
         $params = array(


### PR DESCRIPTION
Change $units to default to 'metric' (ie. Celsius). Fixed bug where the 'list' of forecasts would no longer pull for the Melbourne/Sydney weather feeds.
